### PR TITLE
Custom IHttpHandler to fix BadRequest problem with empty soap body

### DIFF
--- a/AsyncWebServiceRepro/AsyncUtils.cs
+++ b/AsyncWebServiceRepro/AsyncUtils.cs
@@ -34,5 +34,28 @@ namespace AsyncWebServiceRepro
             }, TaskScheduler.Default);
             return tcs.Task;
         }
+
+        public static IAsyncResult AsApm(Task task,
+                            AsyncCallback callback,
+                            object state)
+        {
+            if (task == null)
+                throw new ArgumentNullException(nameof(task));
+
+            var tcs = new TaskCompletionSource<object>(state);
+            task.ContinueWith(t =>
+            {
+                if (t.IsFaulted)
+                    tcs.TrySetException(t.Exception.InnerExceptions);
+                else if (t.IsCanceled)
+                    tcs.TrySetCanceled();
+                else
+                    tcs.TrySetResult(null);
+
+                if (callback != null)
+                    callback(tcs.Task);
+            }, TaskScheduler.Default);
+            return tcs.Task;
+        }
     }
 }

--- a/AsyncWebServiceRepro/AsyncWebServiceRepro.csproj
+++ b/AsyncWebServiceRepro/AsyncWebServiceRepro.csproj
@@ -72,6 +72,8 @@
   </ItemGroup>
   <ItemGroup>
     <Compile Include="AsyncUtils.cs" />
+    <Compile Include="ExceptionHandlingHandler.cs" />
+    <Compile Include="ExceptionHandlingHandlerFactory.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="TestService.asmx.cs">
       <DependentUpon>TestService.asmx</DependentUpon>

--- a/AsyncWebServiceRepro/ExceptionHandlingHandler.cs
+++ b/AsyncWebServiceRepro/ExceptionHandlingHandler.cs
@@ -1,0 +1,79 @@
+﻿using System;
+using System.Threading;
+using System.Threading.Tasks;
+using System.Web;
+
+namespace AsyncWebServiceRepro
+{
+    public class ExceptionHandlingHandler : IHttpAsyncHandler
+    {
+        private ExceptionHandlingHandlerFactory _parent;
+        private IHttpAsyncHandler _originalHandler;
+        private IHttpHandlerFactory _originalFactory;
+        private bool _threwDuringBegin = true;
+
+        public ExceptionHandlingHandler(IHttpAsyncHandler originalHandler, IHttpHandlerFactory originalFactory)
+        {
+            _originalHandler = originalHandler;
+            _originalFactory = originalFactory;
+        }
+
+        #region IHttpHandler Members
+
+        public bool IsReusable => _originalHandler.IsReusable;
+
+        public IAsyncResult BeginProcessRequest(HttpContext context, AsyncCallback cb, object state)
+        {
+            return AsyncUtils.AsApm(ProcessRequestAsync(context), cb, state);
+        }
+
+        private IAsyncResult BeginProcessRequestWrapped(HttpContext context, AsyncCallback cb, object state)
+        {
+            var result = _originalHandler.BeginProcessRequest(context, cb, state);
+            _threwDuringBegin = false;
+            return result;
+        }
+
+        public void EndProcessRequest(IAsyncResult iar)
+        {
+            ((Task)iar).GetAwaiter().GetResult();
+        }
+
+        private async Task ProcessRequestAsync(HttpContext context)
+        {
+            try
+            {
+                await Task.Factory.FromAsync(BeginProcessRequestWrapped,
+                                             _originalHandler.EndProcessRequest,
+                                             context,
+                                             null,
+                                             TaskCreationOptions.None);
+            }
+            catch (Exception e) // Might want to only catch XmlException if wanting to only change behavior of single failure case
+            {
+                // If _threwDuringBegin is false, then any service exceptions should already be handled and this is a different issue
+                // In which case, let the exception be thrown like normal as we don't know how to handle this different case.
+                if (e is ThreadAbortException || e is StackOverflowException || e is OutOfMemoryException || !_threwDuringBegin)
+                {
+                    throw;
+                }
+
+                // Exception happened during call to BeginProcessRequest. The only code not inside a try/catch which can throw is
+                // protocol.ReadParameters(). We should get the same failure calling ProcessRequest which will handle the failure
+                // correctly.
+                _originalHandler.ProcessRequest(context);
+            }
+        }
+
+        public void ProcessRequest(HttpContext context)
+        {
+            throw new NotImplementedException("This class should only be used for async operations");
+        }
+        #endregion
+
+        internal void ReleaseHandler()
+        {
+            _originalFactory.ReleaseHandler(_originalHandler);
+        }
+    }
+}

--- a/AsyncWebServiceRepro/ExceptionHandlingHandlerFactory.cs
+++ b/AsyncWebServiceRepro/ExceptionHandlingHandlerFactory.cs
@@ -1,0 +1,43 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Web;
+using System.Web.Services.Protocols;
+
+namespace AsyncWebServiceRepro
+{
+    public class ExceptionHandlingHandlerFactory : IHttpHandlerFactory
+    {
+        private IHttpHandlerFactory _innerHandlerFactory = new WebServiceHandlerFactory();
+
+        public IHttpHandler GetHandler(HttpContext context, string requestType, string url, string pathTranslated)
+        {
+            IHttpHandler handler = _innerHandlerFactory.GetHandler(context, requestType, url, pathTranslated);
+            if (handler is IHttpAsyncHandler) // Only change behavior when async
+            {
+                return new ExceptionHandlingHandler((IHttpAsyncHandler)handler, _innerHandlerFactory);
+            }
+            else
+            {
+                return handler;
+            }
+        }
+
+        public void ReleaseHandler(IHttpHandler handler)
+        {
+            if (handler == null)
+            {
+                throw new ArgumentNullException(nameof(handler));
+            }
+
+            if(handler is ExceptionHandlingHandler)
+            {
+                ((ExceptionHandlingHandler)handler).ReleaseHandler();
+            }
+            else
+            {
+                _innerHandlerFactory.ReleaseHandler(handler);
+            }
+        }
+    }
+}

--- a/AsyncWebServiceRepro/Web.config
+++ b/AsyncWebServiceRepro/Web.config
@@ -14,4 +14,11 @@
       <compiler language="vb;vbs;visualbasic;vbscript" extension=".vb" type="Microsoft.CodeDom.Providers.DotNetCompilerPlatform.VBCodeProvider, Microsoft.CodeDom.Providers.DotNetCompilerPlatform, Version=2.0.1.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35" warningLevel="4" compilerOptions="/langversion:default /nowarn:41008 /define:_MYTYPE=\&quot;Web\&quot; /optionInfer+" />
     </compilers>
   </system.codedom>
+	<system.webServer>
+		<handlers>
+			<add verb="POST" path="*.asmx"
+			   name="ExceptionHandlingHandlerFactory"
+			   type="AsyncWebServiceRepro.ExceptionHandlingHandlerFactory" />
+		</handlers>
+	</system.webServer>
 </configuration>


### PR DESCRIPTION
This fixes the problem with receiving an empty soap body for an async method causing a 500 internal server error instead of the correct 400 bad request response.